### PR TITLE
Add AIR Blackbox compliance scanner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Dynamic Interaction: Agents can adapt their actions based on real-time observati
 | [AI-OPS](https://github.com/antoninoLorenzo/AI-OPS) | Platform | Security operations for AI | - Threat detection<br>- Response automation<br>- Security monitoring |
 | [PentAGI](https://github.com/vxcontrol/pentagi/) | Security Tool | Automated penetration testing | - Autonomous AI agents<br>- Professional security tools<br>- Comprehensive monitoring |
 | [Tenuo](https://github.com/tenuo-ai/tenuo) | Authorization Framework | Capability-based authorization for AI agents | - Cryptographic warrants with task-scoped TTLs<br>- Offline verification<br>- Proof-of-possession binding<br>- LangChain/LangGraph/MCP integrations |
+| [AIR Blackbox](https://github.com/airblackbox/air-blackbox-mcp) | Compliance Scanner | EU AI Act compliance scanning and trust layer for AI agents | – Article 9-15 compliance checks<br>– HMAC-SHA256 audit chains<br>– PII tokenization<br>– Prompt injection detection<br>– LangChain/CrewAI/AutoGen/OpenAI integrations |
 
 </div>
 


### PR DESCRIPTION
Added AIR Blackbox to the Security Tools & Frameworks table.

AIR Blackbox is an open-source EU AI Act compliance scanner and trust layer for Python AI agents. It scans code against Articles 9, 10, 11, 12, 14, and 15 and provides framework-specific trust layers for LangChain, CrewAI, AutoGen, OpenAI, and Anthropic SDKs.

GitHub: https://github.com/airblackbox
Website: https://airblackbox.ai
License: Apache 2.0