### PR TITLE
Add Agent Threat Rules (ATR) to Security Tools & Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Dynamic Interaction: Agents can adapt their actions based on real-time observati
 | [AI-OPS](https://github.com/antoninoLorenzo/AI-OPS) | Platform | Security operations for AI | - Threat detection<br>- Response automation<br>- Security monitoring |
 | [PentAGI](https://github.com/vxcontrol/pentagi/) | Security Tool | Automated penetration testing | - Autonomous AI agents<br>- Professional security tools<br>- Comprehensive monitoring |
 | [Tenuo](https://github.com/tenuo-ai/tenuo) | Authorization Framework | Capability-based authorization for AI agents | - Cryptographic warrants with task-scoped TTLs<br>- Offline verification<br>- Proof-of-possession binding<br>- LangChain/LangGraph/MCP integrations |
-| [Agent Threat Rules (ATR)](https://github.com/panguard-ai/agent-threat-rules) | Detection Standard | Open-source AI agent security detection rules | - 76 detection rules for MCP/agent threats<br>- 62.7% recall, 99.7% precision (PINT benchmark)<br>- OWASP Agentic Top 10 full coverage<br>- npm install & one-command scan |
+| [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) | Detection Standard | Open-source AI agent security detection rules | - 108 detection rules for MCP/agent threats<br>- 62.7% MCP recall, 99.7% precision. 96.9% SKILL.md recall. Shipped in Cisco AI Defense<br>- OWASP Agentic Top 10 full coverage<br>- npm install & one-command scan |
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Dynamic Interaction: Agents can adapt their actions based on real-time observati
 | [AI-OPS](https://github.com/antoninoLorenzo/AI-OPS) | Platform | Security operations for AI | - Threat detection<br>- Response automation<br>- Security monitoring |
 | [PentAGI](https://github.com/vxcontrol/pentagi/) | Security Tool | Automated penetration testing | - Autonomous AI agents<br>- Professional security tools<br>- Comprehensive monitoring |
 | [Tenuo](https://github.com/tenuo-ai/tenuo) | Authorization Framework | Capability-based authorization for AI agents | - Cryptographic warrants with task-scoped TTLs<br>- Offline verification<br>- Proof-of-possession binding<br>- LangChain/LangGraph/MCP integrations |
+| [Agent Threat Rules (ATR)](https://github.com/panguard-ai/agent-threat-rules) | Detection Standard | Open-source AI agent security detection rules | - 76 detection rules for MCP/agent threats<br>- 62.7% recall, 99.7% precision (PINT benchmark)<br>- OWASP Agentic Top 10 full coverage<br>- npm install & one-command scan |
 
 </div>
 


### PR DESCRIPTION
## Update (April 2026)

ATR has grown significantly since this PR was first submitted:

- **108 detection rules** across 9 threat categories (v1.1.1 on npm)
- **Adopted by Cisco AI Defense** — 34 rules merged into official skill-scanner ([PR #79](https://github.com/cisco-ai-defense/skill-scanner/pull/79))
- **Threat Cloud live** — 14,979 skill threats processed, 47 rule proposals crystallized
- **PRs pending** at NVIDIA Garak (7.5K stars) and Promptfoo (19.7K stars)
- **Benchmarks**: 96.9% recall / 100% precision on SKILL.md (498 samples), 99.7% precision on MCP (850 samples)
- Install: `npm install agent-threat-rules && npx atr scan .`

---
## Summary

Adds [Agent Threat Rules (ATR)](https://github.com/panguard-ai/agent-threat-rules) to the Security Tools & Frameworks section.

ATR is an open-source AI agent security detection standard with:
- **76 detection rules** covering MCP tool-call and agent instruction threats
- **62.7% recall, 99.7% precision** on the PINT benchmark
- **OWASP Agentic Top 10 full coverage** (10/10 categories)
- One-command scan via npm

The entry follows the existing table format (Project | Type | Description | Features).