### PR TITLE
Add APort to LLM agent security tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ Dynamic Interaction: Agents can adapt their actions based on real-time observati
 | [AI-OPS](https://github.com/antoninoLorenzo/AI-OPS) | Platform | Security operations for AI | - Threat detection<br>- Response automation<br>- Security monitoring |
 | [PentAGI](https://github.com/vxcontrol/pentagi/) | Security Tool | Automated penetration testing | - Autonomous AI agents<br>- Professional security tools<br>- Comprehensive monitoring |
 | [Tenuo](https://github.com/tenuo-ai/tenuo) | Authorization Framework | Capability-based authorization for AI agents | - Cryptographic warrants with task-scoped TTLs<br>- Offline verification<br>- Proof-of-possession binding<br>- LangChain/LangGraph/MCP integrations |
+| [APort](https://aport.io/) | Runtime Policy & Verification | Runtime policy and verification layer for AI agents and MCP-connected tools | - Guardrails around tool use<br>- Policy enforcement<br>- Auditable runtime verification |
 | [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) | Detection Standard | Open-source AI agent security detection rules | - 108 detection rules for MCP/agent threats<br>- 62.7% MCP recall, 99.7% precision. 96.9% SKILL.md recall. Shipped in Cisco AI Defense<br>- OWASP Agentic Top 10 full coverage<br>- npm install & one-command scan |
 
 </div>


### PR DESCRIPTION
Summary
- Add APort to the Security Tools & Frameworks resource list as a runtime policy and verification layer for AI agents and MCP-connected tools.

Verification
- git diff --check
- rg -n "APort|aport.io" README.md
- curl.exe -I -L https://aport.io/ returned HTTP 200

Bounty
- aporthq/aport-integrations#19

Payment
- PayPal: https://paypal.me/Jeremytsangchina
- USDT TRC20: TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y