### PR TITLE
Add agentaudit to Security Tools & Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Dynamic Interaction: Agents can adapt their actions based on real-time observati
 | [Viridis MCP](https://github.com/viridis-security/mcp-services-sdk) | MCP Services | Aristotle-verified attribution-enforcement MCP services for AI agents | - /v1/injection/detect (T-IB-02)<br>- /v1/canon/scan (T-IB-05)<br>- /v1/maxwell/challenge (T-IB-09)<br>- Free tier, 7/7 corpus theorems formally proven in Lean 4 by Aristotle (Harmonic) |
 
 | [Agent Memory Guard](https://github.com/OWASP/www-project-agent-memory-guard) | Security Library | OWASP ASI06 memory poisoning defense for AI agents | - Memory integrity validation<br>- Poisoned memory detection<br>- LangChain/LlamaIndex middleware<br>- Audit logging & tenant isolation |
+| [agentaudit](https://github.com/foxck016077/agentaudit) | Scanner/CLI | Heuristic scanner for prompt injection & jailbreak in agent prompts | - Zero-dependency CLI tool<br>- 75% detection on deepset corpus<br>- 0% false-positive on benign roleplay<br>- Free hosted audit UI at https://agent-audit-3u2.pages.dev |
 </div>
 
 <h2 align="center"> Benchmarks & Evaluations </h2>


### PR DESCRIPTION
Adds **agentaudit** — an open-source (MIT), zero-dependency heuristic scanner for prompt-injection, jailbreak, and data-exfil patterns in AI agent prompts and transcripts.

Why it fits this list: it's an agent-focused pre-launch security check (CLI + free hosted UI), not a runtime firewall or an eval framework. It flags five categories (instruction override, system-prompt exfiltration, roleplay smuggling, tool-output injection, data-exfil channels).

Honest scope: rules-only, 75% detection on the deepset/prompt-injections set, 0% false-positive on benign role-play prompts. It's a first-gate filter, not a certification.

- Repo: https://github.com/foxck016077/agentaudit
- Live demo: https://agent-audit-3u2.pages.dev